### PR TITLE
1: Adding Elastic as a datastore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ For mongodb data store set your configuration to something like this:
 ```
 
 ### Elasticsearch
-You can also store your configuration right in elasticsearch! The configuration might look something like this:
+You can also store your configuration right in elasticsearch!
+This means you can build dashboards and visualizations about your alerts!
+You could even alert on your alerts if you wanted to!
+ The configuration might look something like this:
 ```json
     "store": {
         "type": "elasticsearch",

--- a/README.md
+++ b/README.md
@@ -27,6 +27,35 @@ Butler uses the @timestamp field to do the "period" filter. [Make sure your inde
 ![Execution](https://github.com/diogolmenezes/elastic-butler/blob/master/_doc/execution.png)
 ![Email](https://github.com/diogolmenezes/elastic-butler/blob/master/_doc/email-2.png)
 
+## Configuration
+A file **config/env.json** exists to allow you to provide configuration for this application. This includes many things like sender configuration and data
+store configuration.
+
+There are 2 main types of data store configuration available. The data store stores your recipes and execution records.
+
+### Mongodb
+For mongodb data store set your configuration to something like this:
+```json
+    "store": {
+        "type": "mongo",
+        "uri": "mongodb://localhost:27017/elastic-butler",
+        "options": {
+            "useMongoClient": true
+        }
+    },
+```
+
+### Elasticsearch
+You can also store your configuration right in elasticsearch! The configuration might look something like this:
+```json
+    "store": {
+        "type": "elasticsearch",
+        "uri": "http://localhost:9200",
+        "recipeIndex": "elastic_butler_recipe",
+        "executionIndex": "elastic_butler_execution"
+    },
+```
+
 ## Recipes
 
 Butler will search for recipes at your mongo database.

--- a/config/env.json
+++ b/config/env.json
@@ -3,11 +3,11 @@
         "dateOnIndex": false,
         "lookForRecipeUpdatesInterval": 10
     },
-    "db": {
-        "uri": "mongodb://localhost:27017/elastic-butler",
-        "options": {
-            "useMongoClient": true
-        }
+    "store": {
+        "type": "elasticsearch",
+        "uri": "http://localhost:9200",
+        "recipeIndex": "elastic_butler_recipe",
+        "executionIndex": "elastic_butler_execution"
     },
     "senders": {
         "gmail": {

--- a/config/env.json
+++ b/config/env.json
@@ -4,10 +4,11 @@
         "lookForRecipeUpdatesInterval": 10
     },
     "store": {
-        "type": "elasticsearch",
-        "uri": "http://localhost:9200",
-        "recipeIndex": "elastic_butler_recipe",
-        "executionIndex": "elastic_butler_execution"
+        "type": "mongo",
+        "uri": "mongodb://localhost:27017/elastic-butler",
+        "options": {
+            "useMongoClient": true
+        }
     },
     "senders": {
         "gmail": {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 const config   = require('./config');
 const database = require('./config/database');
 
-database.connect(config.db);
+if(config.store.type === "mongo") {
+    database.connect(config.store);
+}
 
 // starting the worker
 let butler = require('./worker/butler');

--- a/service/executionService.js
+++ b/service/executionService.js
@@ -65,10 +65,9 @@ class ExecutionService {
 
 
         if(config.store.type === "elasticsearch") {
-            await this.client.create({
+            await this.client.index({
                 index: config.store.executionIndex,
                 type: 'execution',
-                id: '1',
                 body: executionObj
             });
 

--- a/service/executionService.js
+++ b/service/executionService.js
@@ -1,26 +1,81 @@
+const elasticsearch = require('elasticsearch');
+const config = require('../config');
+const util = require('./util');
+
 class ExecutionService {
     constructor() {
+        this.storeType = config.store.type;
+        this.executionIndex = config.store.executionIndex;
         this.model = require('../model/execution');
+
+        if(this.storeType === "elasticsearch") {
+            this.client = new elasticsearch.Client({
+                host: config.store.uri
+            });
+        }
     };
 
-    find(query) {
-        return this.model.find(query);
+    async find(query) {
+        if(this.storeType === "elasticsearch") {
+            await this.client.search({
+                index: index,
+                body: query
+            })
+            .then((searchResult) => {
+                return util.getSourceArrayFromElasticHits(searchResult.hits.hits);
+            });
+        } else if (this.storeType === "mongo") {
+            return this.model.find(query);
+        }
+        return null;
     };
 
-    findLast() {
-        return this.model.find({}).sort({ created_at: -1 }).limit(500);
+    async findLast() {
+        if(this.storeType === "elasticsearch") {
+            await client.search({
+                index: this.recipeIndex,
+                body: {
+                    sort: [{
+                        "created_at": {
+                            order: "desc"
+                        }
+                    }],
+                    limit: 500
+                }
+            })
+            .then((searchResult) => {
+                return util.getSourceArrayFromElasticHits(searchResult.hits.hits);
+            });
+        } else if (this.storeType === "mongo") {
+            return this.model.find({}).sort({ created_at: -1 }).limit(500);
+        }
+
+        return null;
     };
 
-    save(recipe, hits, firedAction, result) {
+    async save(recipe, hits, firedAction, result) {
         console.log(`Butler => Saving process result for recipe [${recipe.application}] [${recipe.name}]`);
-        let execution = new this.model({
+        let executionObj = {
             recipe: recipe,
             hits: hits,
             firedAction: firedAction,
             result: result,
             created_at: new Date()
-        });
-        return execution.save();
+        }
+
+
+        if(config.store.type === "elasticsearch") {
+            await this.client.create({
+                index: config.store.executionIndex,
+                type: 'execution',
+                id: '1',
+                body: executionObj
+            });
+
+        } else if (config.store.type === "mongo") {
+            let execution = new this.model(executionObj);
+            return execution.save();
+        }
     };
 };
 

--- a/service/recipeService.js
+++ b/service/recipeService.js
@@ -1,14 +1,60 @@
+const elasticsearch = require('elasticsearch');
+const config = require('../config');
+const util = require('./util');
+
 class RecipeService {
     constructor() {
+        this.storeType = config.store.type;
+        this.recipeIndex = config.store.recipeIndex;
         this.model = require('../model/recipe');
+
+        if(this.storeType === "elasticsearch") {
+            this.client = new elasticsearch.Client({
+                host: config.store.uri
+            });
+        }
     };
 
-    find(query) {
-        return this.model.find(query);
+    async find(query) {
+
+        if(this.storeType === "elasticsearch") {
+            await this.client.search({
+                index: index,
+                body: query
+            })
+            .then((searchResult) => {
+                return util.getSourceArrayFromElasticHits(searchResult.hits.hits);
+            });
+        } else if (this.storeType === "mongo") {
+            return this.model.find(query);
+        }
+
+        return null;
+
     };
 
-    findActive() {
-        return this.model.find({ active: true });
+    async findActive() {
+        if(this.storeType === "elasticsearch") {
+            let hits;
+            await this.client.search({
+                index: this.recipeIndex,
+                body: {
+                    query: {
+                        match: {
+                            active: true
+                        }
+                    }
+                }
+            })
+            .then((searchResult) => {
+                hits = util.getSourceArrayFromElasticHits(searchResult.hits.hits);
+            });
+            return hits;
+        } else if (this.storeType === "mongo") {
+            return this.model.find({ active: true });
+        }
+
+        return null;
     };
 };
 

--- a/service/util.js
+++ b/service/util.js
@@ -21,6 +21,16 @@ class Util {
         if (interval === 'week')
             return { initialDate: this.moment().startOf('week'), finalDate: this.moment().endOf('week') };
     };
+
+    getSourceArrayFromElasticHits(hits) {
+        let resultArray = [];
+
+        hits.forEach((hit) => {
+            resultArray.push(hit._source);
+        });
+        
+        return resultArray;
+    }
 };
 
 module.exports = new Util();

--- a/setup.js
+++ b/setup.js
@@ -37,7 +37,7 @@ if(config.store.type === "elasticsearch") {
       });
 
 } else if (config.store.type === "mongo") {
-    database.connect(config.db);
+    database.connect(config.store);
     var recipe = new Recipe(recipeObj);
     recipe.save();
 }

--- a/setup.js
+++ b/setup.js
@@ -30,10 +30,9 @@ if(config.store.type === "elasticsearch") {
         host: config.store.uri
     });
 
-    client.create({
+    client.index({
         index: config.store.recipeIndex,
         type: 'recipe',
-        id: '1',
         body: recipeObj
       });
 

--- a/setup.js
+++ b/setup.js
@@ -1,10 +1,10 @@
+const elasticsearch = require('elasticsearch')
+
 const config = require('./config');
 const database = require('./config/database');
 const Recipe = require('./model/recipe');
 
-database.connect(config.db);
-
-var recipe = new Recipe({
+let recipeObj = {
     name: 'test-recipe',
     application: 'test',
     active: true,
@@ -23,6 +23,22 @@ var recipe = new Recipe({
         subject: '[#hits#] hits at [#application# #recipe#]',
         body: '<p>Your recipe results:</p> #detail#'
     }
-});
+};
 
-recipe.save();
+if(config.store.type === "elasticsearch") {
+    let client = new elasticsearch.Client({
+        host: config.store.uri
+    });
+
+    client.create({
+        index: config.store.recipeIndex,
+        type: 'recipe',
+        id: '1',
+        body: recipeObj
+      });
+
+} else if (config.store.type === "mongo") {
+    database.connect(config.db);
+    var recipe = new Recipe(recipeObj);
+    recipe.save();
+}

--- a/worker/butler.js
+++ b/worker/butler.js
@@ -59,8 +59,12 @@ class Butler {
         console.log(`Butler => Looking for recipes...`);
 
         this.recipeService.findActive()
-            .then(recipes => {                
-                return recipes.map(recipe => recipe.toObject());
+            .then(recipes => {
+                if(this.config.store.type === "mongo") {
+                    return recipes.map(recipe => recipe.toObject());
+                } else {
+                    return recipes;
+                }
             })
             .then(recipes => {
 


### PR DESCRIPTION
# Description
Issue #1 Adding elastic as a datastore option.
* You can configure the index to store recipes
* You can configure the index to store executions
* You can configure the elastic instance to store this data
* Because execution data is stored in elastic, you can create dashboards and visualizations based on alerts (or even alert on alerts for that matter).

Looks like I can't add reviewers so I'll just tag you here :) @diogolmenezes 